### PR TITLE
RAG 검색 속도 향상

### DIFF
--- a/hybrid_search/hybrid_search_opensearch.py
+++ b/hybrid_search/hybrid_search_opensearch.py
@@ -1,94 +1,277 @@
 import os
-import requests
+import warnings
 import numpy as np
+from langchain_upstage import UpstageEmbeddings
 from dotenv import load_dotenv
 from opensearchpy import OpenSearch
+from time import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Tuple, Any, Optional
 
-# 환경변수 로드
+warnings.filterwarnings("ignore")
+# Load environment variables
 load_dotenv()
-opensearch_password = os.getenv("opensearch_password")
+UPSTAGE_API_KEY = os.getenv("UPSTAGE_API_KEY")
+OPENSEARCH_KEY = os.getenv("OPENSEARCH_KEY")
+host = "192.168.0.152"
+port = 9200
+opensearch_auth = ('admin', OPENSEARCH_KEY)
+# Set up the embedding function
+embedding_function = UpstageEmbeddings(
+  api_key=UPSTAGE_API_KEY,
+  model="solar-embedding-1-large"
+)
 
-# OpenSearch 클라이언트 연결
-client = OpenSearch(
-    hosts=[{'host': 'localhost', 'port': 9200}],
-    http_auth=('admin', opensearch_password),
+# Connect to OpenSearch client
+opensearch_client = OpenSearch(
+    hosts=[{'host': host, 'port': port}],
+    http_auth=opensearch_auth,
     use_ssl=True,
     verify_certs=False
 )
 
-# Upstage Solar 모델로 임베딩 생성
-def get_embedding(query_text):
-    return get_embedding_from_solar(query_text)
+def normalize_tmm(scores, fixed_min_value=0.0):
+	arr = np.array(scores)
+	max_value = np.max(arr)
+	norm_score = (arr - fixed_min_value) / (max_value - fixed_min_value)
+	return norm_score
 
-# RRF로 결합하는 함수
-def reciprocal_rank_fusion(bm25_results, neural_results):
-    fusion_scores = {}
-    
-    # BM25 결과 순위 기반 점수 부여
-    for rank, hit in enumerate(bm25_results):
-        doc_id = hit['_id']
-        score = 1 / (rank + 1)
-        if doc_id not in fusion_scores:
-            fusion_scores[doc_id] = 0
-        fusion_scores[doc_id] += score
 
-    # Neural 검색 결과 순위 기반 점수 부여
-    for rank, hit in enumerate(neural_results):
-        doc_id = hit['_id']
-        score = 1 / (rank + 1)
-        if doc_id not in fusion_scores:
-            fusion_scores[doc_id] = 0
-        fusion_scores[doc_id] += score
+def keyword_multi_search(query, index_names, size, text_field):
+    response = opensearch_client.search(
+        index=index_names,  # 리스트로 전달
+        body={
+            "query": {
+                "multi_match": {
+                    "query": query,
+                    "fields": [text_field]  # 필드 이름은 인덱스에서 동일
+                }
+            },
+            "size": size
+        }
+    )
+    # Extract documents and include OpenSearch document ID
+    docs = []
+    for hit in response['hits']['hits']:
+        source = hit['_source']
+        source['id'] = hit['_id']  # Include the document ID
+        docs.append({'doc': source, 'score': hit['_score']})
+    return docs
 
-    # 점수 순으로 정렬
-    sorted_fusion = sorted(fusion_scores.items(), key=lambda item: item[1], reverse=True)
-    return sorted_fusion
+def vector_multi_search(query, index_names, size, vector_field):
+    # OpenAI 또는 사용자 정의 임베딩 생성 함수로 임베딩 생성
+    embedding = embedding_function.embed_query(query)
 
-# OpenSearch 하이브리드 검색 쿼리
-def hybrid_search(query_text, index_name):
-    # Solar API로 임베딩 생성
-    query_vector = get_embedding(query_text)
-    
-    # BM25 기반 multi_match 검색
-    bm25_query = {
-        "query": {
-            "multi_match": {
-                "query": query_text,
-                "fields": ["title", "description"]
+    # 단일 필드에 대한 벡터 검색 쿼리 생성
+    knn_query = {
+        "knn": {
+            vector_field: {
+                "vector": embedding,
+                "k": size  # 상위 k개 결과를 반환
             }
         }
     }
-    bm25_results = client.search(index=index_name, body=bm25_query)['hits']['hits']
 
-    # Neural 기반 시멘틱 검색 (여러 필드에서 각각 상위 3개씩 검색)
-    neural_query = {
-        "knn": {
-            "queries": [
-                {
-                    "field": "behavior_emb",
-                    "query_vector": query_vector,
-                    "k": 3
-                },
-                {
-                    "field": "behavior_analysis_emb",
-                    "query_vector": query_vector,
-                    "k": 3
-                }
-            ]
-        }
+    # 벡터 검색 쿼리 생성
+    search_query = {
+        "size": size,
+        "query": knn_query  # 단일 필드에 대한 KNN 검색
     }
-    neural_results = client.search(index=index_name, body=neural_query)['hits']['hits']
 
-    # RRF로 결과 결합
-    final_results = reciprocal_rank_fusion(bm25_results, neural_results)
-    return final_results
+    # 여러 인덱스를 대상으로 검색
+    response = opensearch_client.search(
+        index=index_names,  # 인덱스 리스트 또는 쉼표로 구분된 문자열을 전달
+        body=search_query
+    )
+    
+    # 검색 결과 처리
+    hits = response['hits']['hits']
+    
+    results = []
+    for hit in hits:
+        doc_content = {}
+        doc_content['id'] = hit["_id"]  # 문서 ID
+        for key, value in hit["_source"].items():
+            doc_content[key] = value  # 메타데이터
+        results.append({'doc': doc_content, 'score': hit["_score"]})
 
-# 검색 실행
+    return results
+
+# BM25 keyword search function
+def keyword_search(query, index_name, size, text_field, field=None, user_no=None):
+    if field=="chat":
+        response = opensearch_client.search(
+            index=index_name,
+            body={
+                "size": size,
+                "query": {
+                    "bool": {
+                        "must": {
+                            "match": {
+                                text_field: query  # text_field에 쿼리 검색
+                            }
+                        },
+                        "filter": {
+                            "term": {
+                                "user_no": user_no  # user_no에 따라 필터링
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    else:
+        response = opensearch_client.search(
+            index=index_name,
+            body={
+                "query": {
+                    "match": {
+                        text_field: query  # text_field is passed here
+                    }
+                },
+                "size": size
+            }
+        )
+    # Extract documents and include OpenSearch document ID
+    docs = []
+    for hit in response['hits']['hits']:
+        source = hit['_source']
+        source['id'] = hit['_id']  # Include the document ID
+        docs.append({'doc': source, 'score': hit['_score']})
+    return docs
+
+
+# Vector search function
+def vector_search(query, index_name, size, text_field, vector_field, pk, field=None, user_no=None):
+    # OpenAI 또는 사용자 정의 임베딩 생성 함수로 임베딩 생성
+    embedding = embedding_function.embed_query(query)
+    
+    if field == "chat":
+        # 유저 번호에 따라 필터링이 필요한 경우
+        pre_filter = {
+            "term": {
+                "user_no": user_no  # user_no에 따라 필터링
+            }
+        }
+        # OpenSearch k-NN 쿼리 작성 (L2 거리)
+        search_query = {
+            "size": size,
+            "query": {
+                "bool": {
+                    "filter": pre_filter,
+                    "must": {
+                        "knn": {
+                            vector_field: {
+                                "vector": embedding,
+                                "k": size  # 상위 k개 결과를 반환
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    else:
+        # 필터가 없는 경우 기본 벡터 검색 (L2 거리)
+        search_query = {
+            "size": size,
+            "query": {
+                "knn": {
+                    vector_field: {
+                        "vector": embedding,
+                        "k": size  # 상위 k개 결과를 반환
+                    }
+                }
+            }
+        }
+    
+    response = opensearch_client.search(
+        index=index_name,
+        body=search_query
+    )
+    
+    # 검색 결과 처리
+    hits = response['hits']['hits']
+    
+    results = []
+    for hit in hits:
+        doc_content = {}
+        doc_content['id'] = hit["_id"]  # 문서 ID
+        for key, value in hit["_source"].items():
+            doc_content[key] = value  # 메타데이터
+        results.append({'doc': doc_content, 'score': hit["_score"]}) 
+    return results
+
+# Perform searches once and reuse results for all hybrid search algorithms
+def perform_multi_searches(query, index_names, text_field, vector_field, size):
+    # Perform BM25 and vector searches once
+    with ThreadPoolExecutor() as executor:
+        bm25_future = executor.submit(keyword_multi_search, query, index_names, size, text_field)
+        vector_future = executor.submit(vector_multi_search, query, index_names, size, vector_field)
+        
+        bm25_results = bm25_future.result()
+        vector_results = vector_future.result()
+    return bm25_results, vector_results
+
+# Perform searches once and reuse results for all hybrid search algorithms
+def perform_searches(query, index_name, text_field, vector_field, size, pk, field=None, user_no=None):
+    # Perform BM25 and vector searches once
+    with ThreadPoolExecutor() as executor:
+        bm25_future = executor.submit(keyword_search, query, index_name, size, text_field, field, user_no)
+        vector_future = executor.submit(vector_search, query, index_name, size, text_field, vector_field, pk, field, user_no)
+        
+        bm25_results = bm25_future.result()
+        vector_results = vector_future.result()
+    return bm25_results, vector_results
+
+def tmmcc_hybrid_search_with_results(bm25_results, vector_results, bm25_weight=0.3, vector_weight=0.7):
+    # Extract BM25 and vector scores
+    bm25_scores = [res['score'] for res in bm25_results]
+    vector_scores = [res['score'] for res in vector_results]
+    
+    # Normalize both sets of scores
+    norm_bm25_scores = normalize_tmm(bm25_scores, fixed_min_value=0.0) if len(bm25_scores) != 0 else bm25_scores
+    norm_vector_scores = normalize_tmm(vector_scores, fixed_min_value=0.0) if len(vector_scores) != 0 else vector_scores
+    combined_scores = {}
+    for i, bm25_res in enumerate(bm25_results):
+        doc_id = bm25_res['doc']['id']
+        bm25_norm_score = norm_bm25_scores[i] * bm25_weight
+        combined_scores[doc_id] = bm25_norm_score
+    
+    for i, vector_res in enumerate(vector_results):
+        doc_id = vector_res['doc']['id']
+        vector_norm_score = norm_vector_scores[i] * vector_weight
+        if doc_id in combined_scores:
+            combined_scores[doc_id] += vector_norm_score
+        else:
+            combined_scores[doc_id] = vector_norm_score
+    # Sort the documents based on combined TMMCC scores
+    sorted_docs = sorted(combined_scores.items(), key=lambda x: x[1], reverse=True)
+
+    # Retrieve the documents based on sorted scores
+    docs = []
+    for doc_id, score in sorted_docs:
+        doc = next((res['doc'] for res in bm25_results if res['doc']['id'] == doc_id), None)
+        if not doc:
+            doc = next((res['doc'] for res in vector_results if res['doc']['id'] == doc_id), None)
+        if doc:
+            docs.append([doc, score])
+    return docs
+
+# Main execution block
 if __name__ == "__main__":
-    index_name = 'video_data'
-    query_text = "example search keyword"
-    
-    
-    # 하이브리드 검색 실행
-    results = hybrid_search(query_text, index_name)
-    print("Hybrid search results with RRF:", results)
+    query_text = "아이가 말끝마다 '싫어'라고 대답하는데 어떻게 하면 말을 듣게 할 수 있을까요?"
+    text_field = "behavior_analysis"
+    vector_field = "behavior_analysis_emb"
+    size = 5
+    bm25_weight = 0.2
+    vector_weight = 0.8
+    pk='prob_no'
+    index_name = "data_video"
+    bm25_result, vector_result = perform_searches(query_text, index_name, text_field, vector_field, size=size, pk=pk)
+
+    tmmcc_results = tmmcc_hybrid_search_with_results(bm25_result, vector_result, bm25_weight=bm25_weight, vector_weight=vector_weight)
+    for index, (doc, score) in enumerate(tmmcc_results):
+        print(f"{index} 순위의 behavior:\n {doc[text_field]}")
+        print(f"Combined Score: {score}")
+        print("-" * 10)
+    print("*"*50)

--- a/search_module/search_api.py
+++ b/search_module/search_api.py
@@ -1,5 +1,4 @@
 import os
-from time import time
 from openai import OpenAI
 from dotenv import load_dotenv
 from pydantic import BaseModel
@@ -7,7 +6,7 @@ from typing import List, Dict, Optional
 from opensearchpy import OpenSearch
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from search_module.search_index import search_video, search_document, search_community, search_chat, generate_rag_response
+from search_module.search_index import search_video, search_document, search_community, search_chat, generate_rag_response, search_video_document
 load_dotenv()
 
 app = FastAPI()
@@ -109,20 +108,11 @@ async def embedCommunity(content_data: CommunityContent):
 
 @app.post("/search/chat")
 async def RAG_chat(chat_content: ChatContent):
-    print("*"*100)
-    results_start = time()
     query = chat_content.messages[-1]['content']
-    video_results = search_video(query)[:3]
-    document_results = search_document(query)[:3]
-    results_end = time()
-    print(f"서치하는데 걸리는 시간 : {results_end - results_start}")
-    rag_start = time()
-    rag_response = generate_rag_response(query, chat_content.messages, video_results + document_results)  # RAG 로직 호출
-    rag_end = time()
-    print(f"답변하는데 걸리는 시간 : {rag_end - rag_start}")
-    print(f"총 걸린 시간 : {rag_end - results_start}")
-    print("*"*100)
+    results = search_video_document(query)[:6]
+    rag_response = generate_rag_response(query, chat_content.messages, results)  # RAG 로직 호출
     return {"result": rag_response}
+
 
 @app.post("/search/unified")
 async def unified_search(search_query: SearchQuery):


### PR DESCRIPTION
### 🌈이슈 번호
- #16 

---

### 🌿작업중인 브랜치
- feature/16-search_performance_optimization

---

### 🛠기능 구현 설명
- 통합검색 속도 5초에서 2.3초로 단축
- RAG 검색에서 multi index검색을 사용해서 0.5초 단축
- RAG 검색에서 semtic search를 langchain대신 opensearch내장 함수를 사용하여 시간 2.8초에서 1.6초로 단축
---

### 📑체크리스트
- [x] 코드가 올바르게 동작하는지 확인함
- [x] 테스트를 추가하거나 수정함
- [x] 코드에 주석을 추가함
- [x] 관련 이슈 번호를 제목과 템플릿에 명시함

---

### ✏️추가사항(이미지 첨부)
-
